### PR TITLE
Move body getter inside event handler

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -30,10 +30,11 @@
         <script type="text/javascript">
           (function() {
 
-            var body = document.body,
-                timer;
+            var timer;
 
             window.addEventListener('scroll', function() {
+              var body = document.body;
+              
               clearTimeout(timer);
               if(!body.classList.contains('disable-hover')) {
                 body.classList.add('disable-hover')


### PR DESCRIPTION
В хроме сейчас в консоль постоянно валится ошибка. Потому что присвоение в переменную `body` делается слишком рано, элемента ещё нет в дом-дереве.
